### PR TITLE
install icepyx with conda instead of pip

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -37,7 +37,7 @@ dependencies:
 - flake8
 - jupyter-offlinenotebook
 - sidecar
+- icepyx
 - pip
 - pip:
-  - icepyx
   - python-cmr


### PR DESCRIPTION
icepyx recently became available on conda-forge, so it no longer requires a pip install during directory setup.