### PR TITLE
Add ATM decimate code and more markdown clarification

### DIFF
--- a/notebooks/iceflow/3_dataviz.ipynb
+++ b/notebooks/iceflow/3_dataviz.ipynb
@@ -222,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/iceflow/4_time_series_tutorial.ipynb
+++ b/notebooks/iceflow/4_time_series_tutorial.ipynb
@@ -49,7 +49,7 @@
     }
    },
    "source": [
-    "### 1. NASA's Earthdata Credentials\n",
+    "## 1. NASA's Earthdata Credentials\n",
     "\n",
     "To access data using the *IceFlow* library and *icepyx* package, it is necessary to log into [Earthdata Login](https://urs.earthdata.nasa.gov/). To do this, enter your NASA Earthdata credentials in the next step after executing the following code cell.\n",
     "\n",
@@ -116,14 +116,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1. Available data by mission\n",
-    "`ATM1B` (Airborne Topographic Mapper sensor) = Pre-IceBridge (BLATM1B) & IceBridge (ILATM1B) \n",
+    "#### 2.1. Available data\n",
     "\n",
-    "`ILVIS2` (Land, Vegetation, and Ice sensor) = IceBridge (*Note*: Due to the nature of this product, IceFlow doesn't provide a common dictionary. Data is accessible, but the user will need to harmonize the data to their own specifications.)\n",
+    "|IceFlow Name | Data Set| Spatial Coverage | Temporal Coverage| Mission  | Sensors  |\n",
+    "|-------------|---------|------------------|------------------|----------|----------|\n",
+    "**ATM1B** |[BLATM L1B](https://nsidc.org/data/BLATM1B)| South: N:-53, S: -90, E:180, W:-180 <br> North: N:90, S: 60, E:180, W:-180 | 23 Jun. 1993 - 30 Oct. 2008 | Pre-IceBridge | ATM  | \n",
+    "**ATM1B** |[ILATM L1B V1](https://nsidc.org/data/ILATM1B/versions/1) | South: N:-53, S: -90, E:180, W:-180 <br> North: N:90, S: 60, E:180, W:-180 | 31 Mar. 2009 - 8 Nov. 2012  <br> (updated 2013) | IceBridge | ATM | \n",
+    "**ATM1B** |[ILATM L1B V2](https://nsidc.org/data/ILATM1B/versions/2)| South: N:-53, S: -90, E:180, W:-180 <br> North: N:90, S: 60, E:180, W:-180 | 20 Mar. 2013 - 16 May 2019  <br> (updated 2020)| IceBridge|ATM|\n",
+    "**ILVIS2** |[ILVIS2](https://nsidc.org/data/ILVIS2)| North: N:90, S: 60, E:180, W:-180|25 Aug. 2017 - 20 Sept. 2017|IceBridge | ALTIMETERS, LASERS, LVIS |\n",
+    "**GLAH06** |[GLAH06](https://nsidc.org/data/GLAH06/)| Global: N:86, S: -86, E:180, W:-180|20 Feb. 2003 - 11 Oct. 2009|ICESat/GLAS | ALTIMETERS, CD, GLAS, GPS, <br> GPS Receiver, LA, PC|\n",
     "\n",
-    "`GLAH06` (GLAS sensor) = ICESat\n",
+    "**Notes**:\n",
+    "* Due to the nature of the **ILVIS2** product, IceFlow doesn't provide a common dictionary. Data is accessible, but the user will need to harmonize the data to their own specifications.\n",
+    "* If you have questions about the data sets please refer to the user guides or contact NSIDC user services at nsidc@nsidc.org\n",
     "\n",
-    "`ATL0X` (ATLAS sensor) = ICESat-2\n",
+    "--- \n",
+    "\n",
     "\n",
     "#### 2.2. Choosing Corrections: Using the ITRF and Epoch values\n",
     "* The differences between ITRF corrections is negligible in most cases, and corrections should only be applied by users who are familiar with the procedures behind these corrections.\n",
@@ -150,6 +158,7 @@
     }
    },
    "source": [
+    "---\n",
     "#### 2.3. Accessing Data with the *IceFlow* Access Widget\n",
     "The *IceFlow* access widget is a user interface tool to visualize flightpaths from IceBridge, draw a region of interest, set spatio-temporal parameters and place data orders to the *IceFlow* API and *icepyx* package without the need to write code.\n",
     "The output of the operations performed in the widget can be seen in the log window (right-most icon at the bottom of your browser.) \n",
@@ -178,7 +187,8 @@
     }
    },
    "source": [
-    "#### 2.3. Accessing data with the *IceFlow* API"
+    "---\n",
+    "#### 2.4. Accessing data with the *IceFlow* API"
    ]
   },
   {
@@ -323,7 +333,8 @@
     }
    },
    "source": [
-    "#### 2.3. Downloading ICESat-2 data [directly] with *icepyx*\n",
+    "---\n",
+    "#### 2.5. Downloading ICESat-2 data [directly] with ***icepyx***\n",
     "Behind the scenes, *IceFlow* is using the [*icepyx*](https://icepyx.readthedocs.io/en/latest/) Python package to download ICESat-2 data. *icepyx* is a standalone library that includes its own examples and documentation and welcomes contributions from data users (no previous GitHub or software development experience required!). Thus, it has a lot of additional functionality for querying, subsetting, ordering, and downloading ICESat-2 datasets (with in-the-works additions for data ingest into multiple formats), including making it easier to programmatically download data from multiple regions. Here we highlight some of the data visualization capabilities for exploring data prior to order and download."
    ]
   },
@@ -360,19 +371,29 @@
     }
    },
    "source": [
-    "### 3. Working with the data\n",
+    "## 3. Working with the data\n",
     "Now that we have downloaded our data, we need to make sure that they are in a common format to do analysis across missions.\n",
     "\n",
-    "Although typically we would include all import statements at the start of the workflow, here we have separated them into this section for instructional clarity."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### **Jessica update**: why are we ignoring warnings? I addressed the rest of the comments \n",
+    "Although typically we would include all import statements at the start of the workflow, here we have separated them into this section for instructional clarity.\n",
     "\n",
-    "**Amy Note**: We should explain the libraries we're importing briefly. I generally think it's better practice to put all imports at the very top of the notebook but I don't have any documentation on hand to back that up! In particular we shuold explain why wer're ignoring warnings (and this could probably be in the same code block as the previous block). "
+    "The main Python packages/libraries that will be used in this notebook are:\n",
+    "\n",
+    "* [*cartopy*](https://scitools.org.uk/cartopy/docs/latest/):\n",
+    "A Python package designed for geospatial data processing in order to produce maps and other geospatial data analyses.\n",
+    "* [*geopandas*](https://geopandas.org/): \n",
+    "Library to simplify working with geospatial data in Python (using pandas).\n",
+    "* [*h5py*](https://github.com/h5py/h5py):\n",
+    "Pythonic wrapper around the [*HDF5 library](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) \n",
+    "* [*matplotlib*](https://matplotlib.org/):\n",
+    "Comprehensive library for creating static, animated, and interactive visualizations in Python\n",
+    "* [*vaex*](https://github.com/vaexio/vaex):\n",
+    "High performance Python library for lazy Out-of-Core dataframes (similar to *pandas*), to visualize and explore big tabular data sets\n",
+    "* [*pandas*](https://pandas.pydata.org/):\n",
+    "Open source data analysis and manipulation tool\n",
+    "* [*icepyx*](https://icepyx.readthedocs.io/en/latest/):\n",
+    "Library for ICESat-2 data users\n",
+    " \n",
+    "**Note**: *Warnings* are being ignored to suppress verbose warnings from some libraries (i.e. vaex, h5py). This will not prevent users from seeing errors."
    ]
   },
   {
@@ -388,65 +409,23 @@
     "import cartopy.crs as ccrs #geospatial (mapping) plotting library\n",
     "import cartopy.io.img_tiles as cimgt\n",
     "import geopandas as gpd #add geospatial awareness/functionality to pandas\n",
+    "import h5py\n",
     "from iceflow.processing import IceFlowProcessing as ifp\n",
     "%matplotlib widget\n",
     "import matplotlib.pyplot as plt #Python visualization\n",
+    "import vaex\n",
     "import pandas as pd #data analysis and manipulation tool\n",
+    "import numpy as np\n",
     "import warnings #Python warnings module\n",
     "warnings.filterwarnings(\"ignore\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import h5py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Pre-IceBridge ATM granule data\n",
-    "preib_gdf = ifp.to_geopandas('data/ATM1B-20210423-Sample.h5')\n",
-    "preib_gdf['mission'] = \"IB\"\n",
-    "\n",
-    "# ICESat granule data\n",
-    "glas_gdf = ifp.to_geopandas('data/GLAH06-20210423-Sample.h5')\n",
-    "glas_gdf['mission'] = \"IS\"\n",
-    "\n",
-    "# ICESat-2 granule data\n",
-    "is2_gdf = ifp.to_geopandas('data/ATL06-20181214041627-Sample.h5')\n",
-    "is2_gdf['mission'] = \"IS2\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# first, let's see what's in the harmonized dataframe and its shape.\n",
-    "display(preib_gdf.head(), preib_gdf.shape)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Nic, can you introduce the preib data downscaling here? The plotting is super slow because of the data density for preib_gdf"
+    "#### 3.1. Import data and convert to a geopandas data frame\n",
+    "ICESat, ICESat-2 and IceBridge data can be read in using preconfigured common dictionaries."
    ]
   },
   {
@@ -459,7 +438,149 @@
    },
    "outputs": [],
    "source": [
-    "# we do the same for the ICESat/GLAS dataframe\n",
+    "# ICESat granule data\n",
+    "glas_gdf = ifp.to_geopandas('data/GLAH06-20210423-Sample.h5')\n",
+    "glas_gdf['mission'] = \"IS\"\n",
+    "\n",
+    "# Pre-IceBridge/IceBridge ATM granule data\n",
+    "#preib_gdf = ifp.to_geopandas('data/ATM1B-20210423-Sample.h5')\n",
+    "#preib_gdf['mission'] = \"IB\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ICESat-2 granule data\n",
+    "is2_gdf = ifp.to_geopandas('data/ATL06_20190201020557_05290204_004_01.h5')\n",
+    "is2_gdf['mission'] = \"IS2\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>elevation</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>mission</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>time</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2007-03-22 19:50:29.545575</th>\n",
+       "      <td>69.168590</td>\n",
+       "      <td>-49.326690</td>\n",
+       "      <td>644.330</td>\n",
+       "      <td>POINT (-49.32669 69.16859)</td>\n",
+       "      <td>IS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2007-03-22 19:50:29.570575</th>\n",
+       "      <td>69.167068</td>\n",
+       "      <td>-49.327619</td>\n",
+       "      <td>648.844</td>\n",
+       "      <td>POINT (-49.32762 69.16707)</td>\n",
+       "      <td>IS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2007-03-22 19:50:29.595575</th>\n",
+       "      <td>69.165547</td>\n",
+       "      <td>-49.328545</td>\n",
+       "      <td>651.840</td>\n",
+       "      <td>POINT (-49.32855 69.16555)</td>\n",
+       "      <td>IS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2007-03-22 19:50:29.620575</th>\n",
+       "      <td>69.164027</td>\n",
+       "      <td>-49.329470</td>\n",
+       "      <td>654.344</td>\n",
+       "      <td>POINT (-49.32947 69.16403)</td>\n",
+       "      <td>IS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2007-03-22 19:50:29.645575</th>\n",
+       "      <td>69.162507</td>\n",
+       "      <td>-49.330395</td>\n",
+       "      <td>661.877</td>\n",
+       "      <td>POINT (-49.33040 69.16251)</td>\n",
+       "      <td>IS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                             latitude  longitude  elevation  \\\n",
+       "time                                                          \n",
+       "2007-03-22 19:50:29.545575  69.168590 -49.326690    644.330   \n",
+       "2007-03-22 19:50:29.570575  69.167068 -49.327619    648.844   \n",
+       "2007-03-22 19:50:29.595575  69.165547 -49.328545    651.840   \n",
+       "2007-03-22 19:50:29.620575  69.164027 -49.329470    654.344   \n",
+       "2007-03-22 19:50:29.645575  69.162507 -49.330395    661.877   \n",
+       "\n",
+       "                                              geometry mission  \n",
+       "time                                                            \n",
+       "2007-03-22 19:50:29.545575  POINT (-49.32669 69.16859)      IS  \n",
+       "2007-03-22 19:50:29.570575  POINT (-49.32762 69.16707)      IS  \n",
+       "2007-03-22 19:50:29.595575  POINT (-49.32855 69.16555)      IS  \n",
+       "2007-03-22 19:50:29.620575  POINT (-49.32947 69.16403)      IS  \n",
+       "2007-03-22 19:50:29.645575  POINT (-49.33040 69.16251)      IS  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(212, 5)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Let's see what's in the harmonized dataframe and its shape.\n",
     "display(glas_gdf.head(), glas_gdf.shape)"
    ]
   },
@@ -473,6 +594,259 @@
    "source": [
     "# and again for ICESat-2 ATL06\n",
     "display(is2_gdf.head(), is2_gdf.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2. Down sample IceBridge Data\n",
+    "Due to the size of the IceBridge ATM1B point cloud, it is often difficult to work with or plot data in a Notebook environment. We will downsample the data in this example for faster plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>#                                    </th><th>latitude  </th><th>longitude  </th><th>elevation   </th><th>date                         </th><th>index    </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;0&lt;/i&gt;        </td><td>69.127761 </td><td>-49.493261 </td><td>-1816.333008</td><td>2007-09-20 16:38:11.122000000</td><td>0.0      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;1&lt;/i&gt;        </td><td>69.129082 </td><td>-49.493192 </td><td>-1671.847046</td><td>2007-09-20 16:38:11.394000000</td><td>1.0      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;2&lt;/i&gt;        </td><td>69.130029 </td><td>-49.541076 </td><td>232.735001  </td><td>2008-06-27 16:52:40.187000000</td><td>2.0      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3&lt;/i&gt;        </td><td>69.130081 </td><td>-49.540974 </td><td>233.444     </td><td>2008-06-27 16:52:40.187000000</td><td>3.0      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;4&lt;/i&gt;        </td><td>69.130265 </td><td>-49.540582 </td><td>236.263     </td><td>2008-06-27 16:52:40.240000000</td><td>4.0      </td></tr>\n",
+       "<tr><td>...                                  </td><td>...       </td><td>...        </td><td>...         </td><td>...                          </td><td>...      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3,385,808&lt;/i&gt;</td><td>69.120001 </td><td>-49.52292  </td><td>257.800995  </td><td>2018-04-30 15:00:36.663000000</td><td>3385808.0</td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3,385,809&lt;/i&gt;</td><td>69.11999  </td><td>-49.522447 </td><td>258.140991  </td><td>2018-04-30 15:00:36.664000000</td><td>3385809.0</td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3,385,810&lt;/i&gt;</td><td>69.11999  </td><td>-49.522402 </td><td>256.713013  </td><td>2018-04-30 15:00:36.665000000</td><td>3385810.0</td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3,385,811&lt;/i&gt;</td><td>69.119989 </td><td>-49.522359 </td><td>255.509995  </td><td>2018-04-30 15:00:36.665000000</td><td>3385811.0</td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3,385,812&lt;/i&gt;</td><td>69.119987 </td><td>-49.522316 </td><td>255.248001  </td><td>2018-04-30 15:00:36.665000000</td><td>3385812.0</td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "#          latitude    longitude    elevation     date                           index\n",
+       "0          69.127761   -49.493261   -1816.333008  2007-09-20 16:38:11.122000000  0.0\n",
+       "1          69.129082   -49.493192   -1671.847046  2007-09-20 16:38:11.394000000  1.0\n",
+       "2          69.130029   -49.541076   232.735001    2008-06-27 16:52:40.187000000  2.0\n",
+       "3          69.130081   -49.540974   233.444       2008-06-27 16:52:40.187000000  3.0\n",
+       "4          69.130265   -49.540582   236.263       2008-06-27 16:52:40.240000000  4.0\n",
+       "...        ...         ...          ...           ...                            ...\n",
+       "3,385,808  69.120001   -49.52292    257.800995    2018-04-30 15:00:36.663000000  3385808.0\n",
+       "3,385,809  69.11999    -49.522447   258.140991    2018-04-30 15:00:36.664000000  3385809.0\n",
+       "3,385,810  69.11999    -49.522402   256.713013    2018-04-30 15:00:36.665000000  3385810.0\n",
+       "3,385,811  69.119989   -49.522359   255.509995    2018-04-30 15:00:36.665000000  3385811.0\n",
+       "3,385,812  69.119987   -49.522316   255.248001    2018-04-30 15:00:36.665000000  3385812.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Read in the data and common dictionary\n",
+    "filepath = 'data/ATM1B-20210423-Sample.h5'\n",
+    "atm_key = ifp.get_common_dictionary('ATM')\n",
+    "\n",
+    "f = h5py.File(filepath, 'r')\n",
+    "preib_vx = vaex.open(filepath)\n",
+    "\n",
+    "preib_vx['date'] = preib_vx.utc_datetime.values.astype('datetime64[ns]')\n",
+    "preib_df = atm_vx[atm_key['latitude'], atm_key['longitude'], atm_key['elevation'], 'date']\n",
+    "preib_df.add_column('index', vaex.vrange(0, len(preib_vx)))\n",
+    "display(preib_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>#                                 </th><th>latitude  </th><th>longitude  </th><th>elevation   </th><th>date                         </th><th>index    </th><th>mission  </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;0&lt;/i&gt;     </td><td>69.127761 </td><td>-49.493261 </td><td>-1816.333008</td><td>2007-09-20 16:38:11.122000000</td><td>0.0      </td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;1&lt;/i&gt;     </td><td>69.130141 </td><td>-49.540565 </td><td>240.117004  </td><td>2008-06-27 16:52:40.509000000</td><td>100.0    </td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;2&lt;/i&gt;     </td><td>69.129584 </td><td>-49.541695 </td><td>238.651993  </td><td>2008-06-27 16:52:40.673000000</td><td>200.0    </td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;3&lt;/i&gt;     </td><td>69.129798 </td><td>-49.541006 </td><td>244.223999  </td><td>2008-06-27 16:52:40.833000000</td><td>300.0    </td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;4&lt;/i&gt;     </td><td>69.129254 </td><td>-49.542389 </td><td>240.735992  </td><td>2008-06-27 16:52:40.943000000</td><td>400.0    </td><td>IB       </td></tr>\n",
+       "<tr><td>...                               </td><td>...       </td><td>...        </td><td>...         </td><td>...                          </td><td>...      </td><td>...      </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;33,854&lt;/i&gt;</td><td>69.120412 </td><td>-49.523633 </td><td>247.108002  </td><td>2018-04-30 15:00:36.251000000</td><td>3385400.0</td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;33,855&lt;/i&gt;</td><td>69.119995 </td><td>-49.525912 </td><td>247.442001  </td><td>2018-04-30 15:00:36.327000000</td><td>3385500.0</td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;33,856&lt;/i&gt;</td><td>69.120157 </td><td>-49.521689 </td><td>246.391006  </td><td>2018-04-30 15:00:36.379000000</td><td>3385600.0</td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;33,857&lt;/i&gt;</td><td>69.120001 </td><td>-49.521329 </td><td>250.070007  </td><td>2018-04-30 15:00:36.462000000</td><td>3385700.0</td><td>IB       </td></tr>\n",
+       "<tr><td>&lt;i style=&#x27;opacity: 0.6&#x27;&gt;33,858&lt;/i&gt;</td><td>69.120027 </td><td>-49.522455 </td><td>258.973999  </td><td>2018-04-30 15:00:36.623000000</td><td>3385800.0</td><td>IB       </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "#       latitude    longitude    elevation     date                           index      mission\n",
+       "0       69.127761   -49.493261   -1816.333008  2007-09-20 16:38:11.122000000  0.0        IB\n",
+       "1       69.130141   -49.540565   240.117004    2008-06-27 16:52:40.509000000  100.0      IB\n",
+       "2       69.129584   -49.541695   238.651993    2008-06-27 16:52:40.673000000  200.0      IB\n",
+       "3       69.129798   -49.541006   244.223999    2008-06-27 16:52:40.833000000  300.0      IB\n",
+       "4       69.129254   -49.542389   240.735992    2008-06-27 16:52:40.943000000  400.0      IB\n",
+       "...     ...         ...          ...           ...                            ...        ...\n",
+       "33,854  69.120412   -49.523633   247.108002    2018-04-30 15:00:36.251000000  3385400.0  IB\n",
+       "33,855  69.119995   -49.525912   247.442001    2018-04-30 15:00:36.327000000  3385500.0  IB\n",
+       "33,856  69.120157   -49.521689   246.391006    2018-04-30 15:00:36.379000000  3385600.0  IB\n",
+       "33,857  69.120001   -49.521329   250.070007    2018-04-30 15:00:36.462000000  3385700.0  IB\n",
+       "33,858  69.120027   -49.522455   258.973999    2018-04-30 15:00:36.623000000  3385800.0  IB"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Here we will aggrigate or \"decimate\" the data to make it smaller for our purposes\n",
+    "preib_dec = preib_df[(preib_df.index % 100 == 0)]\n",
+    "ib = np.array([\"IB\"]*len(preib_df))\n",
+    "preib_dec.add_column('mission', ib)\n",
+    "display(preib_dec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>elevation</th>\n",
+       "      <th>date</th>\n",
+       "      <th>mission</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>69.127761</td>\n",
+       "      <td>-49.493261</td>\n",
+       "      <td>-1816.333008</td>\n",
+       "      <td>2007-09-20 16:38:11.122</td>\n",
+       "      <td>IB</td>\n",
+       "      <td>POINT (-49.49326 69.12776)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>69.130141</td>\n",
+       "      <td>-49.540565</td>\n",
+       "      <td>240.117004</td>\n",
+       "      <td>2008-06-27 16:52:40.509</td>\n",
+       "      <td>IB</td>\n",
+       "      <td>POINT (-49.54057 69.13014)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>69.129584</td>\n",
+       "      <td>-49.541695</td>\n",
+       "      <td>238.651993</td>\n",
+       "      <td>2008-06-27 16:52:40.673</td>\n",
+       "      <td>IB</td>\n",
+       "      <td>POINT (-49.54169 69.12958)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>69.129798</td>\n",
+       "      <td>-49.541006</td>\n",
+       "      <td>244.223999</td>\n",
+       "      <td>2008-06-27 16:52:40.833</td>\n",
+       "      <td>IB</td>\n",
+       "      <td>POINT (-49.54101 69.12980)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>69.129254</td>\n",
+       "      <td>-49.542389</td>\n",
+       "      <td>240.735992</td>\n",
+       "      <td>2008-06-27 16:52:40.943</td>\n",
+       "      <td>IB</td>\n",
+       "      <td>POINT (-49.54239 69.12925)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    latitude  longitude    elevation                    date mission  \\\n",
+       "0  69.127761 -49.493261 -1816.333008 2007-09-20 16:38:11.122      IB   \n",
+       "1  69.130141 -49.540565   240.117004 2008-06-27 16:52:40.509      IB   \n",
+       "2  69.129584 -49.541695   238.651993 2008-06-27 16:52:40.673      IB   \n",
+       "3  69.129798 -49.541006   244.223999 2008-06-27 16:52:40.833      IB   \n",
+       "4  69.129254 -49.542389   240.735992 2008-06-27 16:52:40.943      IB   \n",
+       "\n",
+       "                     geometry  \n",
+       "0  POINT (-49.49326 69.12776)  \n",
+       "1  POINT (-49.54057 69.13014)  \n",
+       "2  POINT (-49.54169 69.12958)  \n",
+       "3  POINT (-49.54101 69.12980)  \n",
+       "4  POINT (-49.54239 69.12925)  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(33859, 6)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Now we need to convert our downsampled data back into a pandas geodataframe so we can merge it with the other missions\n",
+    "preib_pandas = preib_dec.to_pandas_df([\"latitude\",\"longitude\", \"elevation\", \"date\", \"mission\"])\n",
+    "\n",
+    "preib_gdf = gpd.GeoDataFrame(preib_pandas,\n",
+    "                                geometry=gpd.points_from_xy(preib_pandas['longitude'],\n",
+    "                                                            preib_pandas['latitude'],\n",
+    "                                                            crs='epsg:4326'))\n",
+    "display(preib_gdf.head(), preib_gdf.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.3. Plot the data from each mission together"
    ]
   },
   {
@@ -501,12 +875,19 @@
     "# world.plot(ax=map_ax, facecolor=\"lightgray\", edgecolor=\"gray\")\n",
     "\n",
     "# ####ATTN: Need to get the correct projection in here!\n",
-    "for onegdf, lab, shp in zip([preib_gdf, glas_gdf, is2_gdf],[\"preib\",\"glas\",\"is2\"], ['P','o','D']):\n",
+    "for onegdf, lab, shp in zip([preib_gdf, glas_gdf],[\"preib\",\"glas\"], ['P','o','D']):\n",
     "    ms=map_ax.scatter(onegdf[\"longitude\"], onegdf[\"latitude\"],  2, c=onegdf[\"elevation\"],\n",
     "                      vmin=0, vmax=1000, label=lab, marker=shp,\n",
     "                      transform=ccrs.Geodetic())\n",
     "\n",
     "plt.colorbar(ms, label='elevation')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.4. Stack the dataframes"
    ]
   },
   {
@@ -516,8 +897,15 @@
    "outputs": [],
    "source": [
     "# Thanks to the harmonization, we can stack our geopandas dataframes to have a unified dataframe for analysis.\n",
-    "stacked_df = gpd.GeoDataFrame(pd.concat([preib_gdf, glas_gdf, is2_gdf]))\n",
+    "stacked_df = gpd.GeoDataFrame(pd.concat([preib_gdf, glas_gdf]))\n",
     "display(stacked_df.head(), stacked_df.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.5. Time series analysis"
    ]
   },
   {


### PR DESCRIPTION
1. Added some better descriptions and clarified datasets/mission names
2. Decimated the ATM data to improve speed, especially for plotting.
3. Omit ILVIS data from order and visualizations
4. Left the projections as geodetic() in cartopy
5. ifp_togeopandas for ICESat-2 still not working for me, so IS2 is not included in stacked_df and plots
