### PR TITLE
updated notebooks with ATL07 end to end

### DIFF
--- a/notebooks/ICESat-2_MODIS_Arctic_Sea_Ice/Customize and Access Data-Rendered.ipynb
+++ b/notebooks/ICESat-2_MODIS_Arctic_Sea_Ice/Customize and Access Data-Rendered.ipynb
@@ -67,15 +67,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dataset_id: ATLAS/ICESat-2 L3A Sea Ice Height V001, version_id: 001\n",
-      "dataset_id: ATLAS/ICESat-2 L3A Sea Ice Height V002, version_id: 002\n"
+      "dataset_id: ATLAS/ICESat-2 L3A Sea Ice Height V003, version_id: 003\n",
+      "dataset_id: ATLAS/ICESat-2 L3A Sea Ice Height V004, version_id: 004\n",
+      "dataset_id: ATLAS/ICESat-2 L3A Sea Ice Height V005, version_id: 005\n"
      ]
     }
    ],
@@ -112,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,12 +132,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "data_dict = {'short_name': 'ATL07', \n",
-    "             'version': '002',\n",
+    "             'version': '005',\n",
     "             'bounding_box': bounding_box, \n",
     "             'temporal': temporal }"
    ]
@@ -152,15 +153,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "There are 3 granules of ATL07 version 002 over my area and time of interest.\n",
-      "The average size of each granule is 260.65 MB and the total size of all 3 granules is 781.94 MB\n"
+      "There are 2 granules of ATL07 version 005 over my area and time of interest.\n",
+      "The average size of each granule is 320.07 MB and the total size of all 2 granules is 640.15 MB\n"
      ]
     }
    ],
@@ -212,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -242,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -306,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,14 +405,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://n5eil02u.ecs.nsidc.org/egi/request?short_name=ATL07&version=002&bounding_box=140,72,153,80&temporal=2019-03-23T00:00:00Z,2019-03-23T23:59:59Z&page_size=2000&email=amy.steiker@nsidc.org&bbox=140,72,153,80&time=2019-03-23T00:00:00,2019-03-23T23:59:59&coverage=/gt1l/sea_ice_segments/delta_time,/gt1l/sea_ice_segments/latitude,/gt1l/sea_ice_segments/longitude,/gt1l/sea_ice_segments/heights/height_segment_confidence,/gt1l/sea_ice_segments/heights/height_segment_height,/gt1l/sea_ice_segments/heights/height_segment_quality,/gt1l/sea_ice_segments/heights/height_segment_surface_error_est,/gt1l/sea_ice_segments/heights/height_segment_length_seg,/gt2l/sea_ice_segments/delta_time,/gt2l/sea_ice_segments/latitude,/gt2l/sea_ice_segments/longitude,/gt2l/sea_ice_segments/heights/height_segment_confidence,/gt2l/sea_ice_segments/heights/height_segment_height,/gt2l/sea_ice_segments/heights/height_segment_quality,/gt2l/sea_ice_segments/heights/height_segment_surface_error_est,/gt2l/sea_ice_segments/heights/height_segment_length_seg,/gt3l/sea_ice_segments/delta_time,/gt3l/sea_ice_segments/latitude,/gt3l/sea_ice_segments/longitude,/gt3l/sea_ice_segments/heights/height_segment_confidence,/gt3l/sea_ice_segments/heights/height_segment_height,/gt3l/sea_ice_segments/heights/height_segment_quality,/gt3l/sea_ice_segments/heights/height_segment_surface_error_est,/gt3l/sea_ice_segments/heights/height_segment_length_seg&request_mode=async\n"
+      "https://n5eil02u.ecs.nsidc.org/egi/request?short_name=ATL07&version=005&bounding_box=140,72,153,80&temporal=2019-03-23T00:00:00Z,2019-03-23T23:59:59Z&page_size=2000&email=amy.steiker@nsidc.org&bbox=140,72,153,80&time=2019-03-23T00:00:00,2019-03-23T23:59:59&coverage=/gt1l/sea_ice_segments/delta_time,/gt1l/sea_ice_segments/latitude,/gt1l/sea_ice_segments/longitude,/gt1l/sea_ice_segments/heights/height_segment_confidence,/gt1l/sea_ice_segments/heights/height_segment_height,/gt1l/sea_ice_segments/heights/height_segment_quality,/gt1l/sea_ice_segments/heights/height_segment_surface_error_est,/gt1l/sea_ice_segments/heights/height_segment_length_seg,/gt2l/sea_ice_segments/delta_time,/gt2l/sea_ice_segments/latitude,/gt2l/sea_ice_segments/longitude,/gt2l/sea_ice_segments/heights/height_segment_confidence,/gt2l/sea_ice_segments/heights/height_segment_height,/gt2l/sea_ice_segments/heights/height_segment_quality,/gt2l/sea_ice_segments/heights/height_segment_surface_error_est,/gt2l/sea_ice_segments/heights/height_segment_length_seg,/gt3l/sea_ice_segments/delta_time,/gt3l/sea_ice_segments/latitude,/gt3l/sea_ice_segments/longitude,/gt3l/sea_ice_segments/heights/height_segment_confidence,/gt3l/sea_ice_segments/heights/height_segment_height,/gt3l/sea_ice_segments/heights/height_segment_quality,/gt3l/sea_ice_segments/heights/height_segment_surface_error_est,/gt3l/sea_ice_segments/heights/height_segment_length_seg&request_mode=async\n"
      ]
     }
    ],
@@ -442,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -451,17 +452,17 @@
      "text": [
       "Request HTTP response:  201\n",
       "\n",
-      "Order request URL:  https://n5eil02u.ecs.nsidc.org/egi/request?short_name=ATL07&version=002&bounding_box=140%2C72%2C153%2C80&temporal=2019-03-23T00%3A00%3A00Z%2C2019-03-23T23%3A59%3A59Z&page_size=2000&email=amy.steiker%40nsidc.org&bbox=140%2C72%2C153%2C80&time=2019-03-23T00%3A00%3A00%2C2019-03-23T23%3A59%3A59&coverage=%2Fgt1l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt1l%2Fsea_ice_segments%2Flatitude%2C%2Fgt1l%2Fsea_ice_segments%2Flongitude%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg%2C%2Fgt2l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt2l%2Fsea_ice_segments%2Flatitude%2C%2Fgt2l%2Fsea_ice_segments%2Flongitude%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg%2C%2Fgt3l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt3l%2Fsea_ice_segments%2Flatitude%2C%2Fgt3l%2Fsea_ice_segments%2Flongitude%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg&request_mode=async\n",
+      "Order request URL:  https://n5eil02u.ecs.nsidc.org/egi/request?short_name=ATL07&version=005&bounding_box=140%2C72%2C153%2C80&temporal=2019-03-23T00%3A00%3A00Z%2C2019-03-23T23%3A59%3A59Z&page_size=2000&email=amy.steiker%40nsidc.org&bbox=140%2C72%2C153%2C80&time=2019-03-23T00%3A00%3A00%2C2019-03-23T23%3A59%3A59&coverage=%2Fgt1l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt1l%2Fsea_ice_segments%2Flatitude%2C%2Fgt1l%2Fsea_ice_segments%2Flongitude%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt1l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg%2C%2Fgt2l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt2l%2Fsea_ice_segments%2Flatitude%2C%2Fgt2l%2Fsea_ice_segments%2Flongitude%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt2l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg%2C%2Fgt3l%2Fsea_ice_segments%2Fdelta_time%2C%2Fgt3l%2Fsea_ice_segments%2Flatitude%2C%2Fgt3l%2Fsea_ice_segments%2Flongitude%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_confidence%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_height%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_quality%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_surface_error_est%2C%2Fgt3l%2Fsea_ice_segments%2Fheights%2Fheight_segment_length_seg&request_mode=async\n",
       "\n",
-      "order ID:  5000000435084\n",
-      "status URL:  https://n5eil02u.ecs.nsidc.org/egi/request/5000000435084\n",
+      "order ID:  5000002720310\n",
+      "status URL:  https://n5eil02u.ecs.nsidc.org/egi/request/5000002720310\n",
       "HTTP response from order response URL:  201\n",
       "\n",
       "Initial request status is  processing\n",
       "\n",
       "Status is not complete. Trying again.\n",
-      "Retry request status is:  complete_with_errors\n",
-      "Zip download URL:  https://n5eil02u.ecs.nsidc.org/esir/5000000435084.zip\n",
+      "Retry request status is:  complete\n",
+      "Zip download URL:  https://n5eil02u.ecs.nsidc.org/esir/5000002720310.zip\n",
       "Beginning download of zipped output...\n",
       "Data request is complete.\n"
      ]
@@ -482,7 +483,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -496,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/ICESat-2_MODIS_Arctic_Sea_Ice/Customize and Access Data.ipynb
+++ b/notebooks/ICESat-2_MODIS_Arctic_Sea_Ice/Customize and Access Data.ipynb
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "CMR_COLLECTIONS_URL = 'https://cmr.earthdata.nasa.gov/search/collections.json' # CMR collection metadata endpoint\n",
-    "response = requests.get(CMR_COLLECTIONS_URL, params={'short_name': 'MOD29'}) # Request metadata of specified short name\n",
+    "response = requests.get(CMR_COLLECTIONS_URL, params={'short_name': 'ATL07'}) # Request metadata of specified short name\n",
     "\n",
     "results = json.loads(response.content) # load JSON results\n",
     "# for each version entry, print version number\n",
@@ -126,8 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_dict = {'short_name': 'MOD29', \n",
-    "             'version': '6',\n",
+    "data_dict = {'short_name': 'ATL07', \n",
+    "             'version': '005',\n",
     "             'bounding_box': bounding_box, \n",
     "             'temporal': temporal }"
    ]
@@ -165,6 +165,8 @@
     "## ***On your own***: Discover data availability for ATL07\n",
     "\n",
     "Go back to the \"Select data set and determine version number\" heading. Replace all `MOD29` instances with `ATL07` along with its most recent version number, keeping your time and area of interest the same. ***Note that ATL07 has a 3-digit version number.*** How does the data volume compare to MOD29? \n",
+    "\n",
+    "**This tutorial was originally taught using the `MOD29` data set as input above. This has already been replaced with `ATL07` so that the notebook can successfully run end-to-end without modifying the above codeblocks.**\n",
     "\n",
     "____"
    ]
@@ -412,7 +414,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -426,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated MODIS ICESAT-2 customize and access notebooks so that they run end to end with ATL07 without having to manually switch dataset from MOD29 as was taught during the original live exercise. 