### PR TITLE
remove 0.5.0 pin

### DIFF
--- a/notebooks/ICESat-2_Cloud_Access/environment/environment.yml
+++ b/notebooks/ICESat-2_Cloud_Access/environment/environment.yml
@@ -9,6 +9,6 @@ dependencies:
  ###################################################
 
  - jupyterlab
- - earthaccess=0.5.0
+ - earthaccess
  - hvplot
  - xarray


### PR DESCRIPTION
There may have been a dependency issue with the build since the main binder environment.yml is specifying earthaccess>=0.5.1 yet we pinned the notebook folder to 0.5.0. 