### PR TITLE
Add xarray.Datatree() guidance for ICESat-2 ATL06 tutorial

### DIFF
--- a/notebooks/ICESat-2_Cloud_Access/ATL06-direct-access.ipynb
+++ b/notebooks/ICESat-2_Cloud_Access/ATL06-direct-access.ipynb
@@ -328,7 +328,7 @@
    "id": "56677586-a2cd-4ddb-8e57-457ced954331",
    "metadata": {},
    "source": [
-    "We can see from the representation of the `xarray.DataTree` object `dt` that there are ten groups in the top, or \"root\", level. Clicking on Groups reveals various Metadata and Ancillary data groups as well as groups representing each of the left and right beam pairs from the ICESat-2 ATLAS instrument*. We can also see that there are no dimensions, coordinates, or data variables in the root group. Data could be read into `numpy` arrays or a `pandas.Dataframe`.  However, each granule would have to be read using a package that reads HDF5 granules such as `h5py`.  `xarray` does this all _under-the-hood_ in a single line. \n",
+    "We can see from the representation of the `xarray.DataTree` object `dt` that there are ten groups in the top, or \"root\", level. Clicking on Groups reveals various Metadata and Ancillary data groups as well as groups representing each of the left and right beam pairs from the ICESat-2 ATLAS instrument*. We can also see that there are no dimensions, coordinates, or data variables in the root group. Reading the data into `numpy` arrays or a `pandas.Dataframe` could be an alternative method to using `xarray.Datatree`. However, each granule (file) would have to be read first using a package that reads HDF5 files such as `h5py`. `xarray` does this all under-the-hood in a single line.\n",
     "\n",
     "*ICESat-2 measures photon returns from 3 beam pairs numbered 1, 2 and 3 that each consist of a left and a right beam. In this case, we are interested in plotting the left ground track (gt) of beam pair 1. "
    ]

--- a/notebooks/ICESat-2_Cloud_Access/ATL06-direct-access_rendered.ipynb
+++ b/notebooks/ICESat-2_Cloud_Access/ATL06-direct-access_rendered.ipynb
@@ -43342,7 +43342,7 @@
    "id": "3392e88a-bf67-45cb-9675-87076d0f5483",
    "metadata": {},
    "source": [
-    "We can see from the representation of the `xarray.DataTree` object `dt` that there are ten groups in the top, or \"root\", level. Clicking on Groups reveals various Metadata and Ancillary data groups as well as groups representing each of the left and right beam pairs from the ICESat-2 ATLAS instrument*. We can also see that there are no dimensions, coordinates, or data variables in the root group. Data could be read into `numpy` arrays or a `pandas.Dataframe`.  However, each granule would have to be read using a package that reads HDF5 granules such as `h5py`.  `xarray` does this all _under-the-hood_ in a single line. \n",
+    "We can see from the representation of the `xarray.DataTree` object `dt` that there are ten groups in the top, or \"root\", level. Clicking on Groups reveals various Metadata and Ancillary data groups as well as groups representing each of the left and right beam pairs from the ICESat-2 ATLAS instrument*. We can also see that there are no dimensions, coordinates, or data variables in the root group. Reading the data into `numpy` arrays or a `pandas.Dataframe` could be an alternative method to using `xarray.Datatree`. However, each granule (file) would have to be read first using a package that reads HDF5 files such as `h5py`. `xarray` does this all under-the-hood in a single line.\n",
     "\n",
     "*ICESat-2 measures photon returns from 3 beam pairs numbered 1, 2 and 3 that each consist of a left and a right beam. In this case, we are interested in plotting the left ground track (gt) of beam pair 1. "
    ]

--- a/notebooks/ICESat-2_Cloud_Access/README.md
+++ b/notebooks/ICESat-2_Cloud_Access/README.md
@@ -9,7 +9,7 @@ This notebook demonstrates searching for cloud-hosted ICESat-2 data and directly
 #### Key Learning Objectives 
 1. Use `earthaccess` to search for ICESat-2 data using spatial and temporal filters and explore search results;
 2. Open data granules using direct access to the ICESat-2 S3 bucket;
-3. Load a HDF5 group into an `xarray.Dataset`;
+3. Load a HDF5 group into an `xarray.DataTree`;
 4. Visualize the land ice heights using `hvplot`.
 
 ### [Plotting ICESat-2 and CryoSat-2 Freeboards](./ICESat2-CryoSat2-Coincident.ipynb)


### PR DESCRIPTION
xarray.Datatree() is now presented in our ATL06 tutorial to demonstrate the ability to open an entire ICESat-2 granule in xarray without having to specify an individual group. There is the need to specify setting phony dims due to insufficient dimension metadata in some of the ancillary groups, however. I utilized the guidance in @andypbarrett 's SMAP PR (#91) for this.